### PR TITLE
feat: bump docker component versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,10 @@ FROM ubuntu:focal-20230801
 ENV DOCKER_CHANNEL=stable \
   DOCKER_VERSION=24.0.5 \
   DOCKER_COMPOSE_VERSION=2.22.0 \
-  DOCKER_SQUASH=0.2.0 \
   DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
-  && apt-get -y install bash curl iptables ca-certificates gnupg net-tools iproute2 make \
+  && apt-get -y install bash curl iptables ca-certificates make pigz \
   && curl -fL "https://download.docker.com/linux/static/${DOCKER_CHANNEL}/x86_64/docker-${DOCKER_VERSION}.tgz" | tar zx \
   && mv /docker/* /bin/ \
   && chmod +x /bin/docker* \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,20 @@
-FROM ubuntu:bionic
+FROM ubuntu:focal-20230801
 
 ENV DOCKER_CHANNEL=stable \
-    DOCKER_VERSION=19.03.2 \
-    DOCKER_COMPOSE_VERSION=1.24.1 \
-    DOCKER_SQUASH=0.2.0 \
-    DEBIAN_FRONTEND=noninteractive
+  DOCKER_VERSION=24.0.5 \
+  DOCKER_COMPOSE_VERSION=2.22.0 \
+  DOCKER_SQUASH=0.2.0 \
+  DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
-        && apt-get -y install bash curl python-pip python-dev iptables util-linux ca-certificates gcc libc-dev libffi-dev libssl-dev make git wget net-tools iproute2 \
-        && curl -fL "https://download.docker.com/linux/static/${DOCKER_CHANNEL}/x86_64/docker-${DOCKER_VERSION}.tgz" | tar zx \
-        && mv /docker/* /bin/ \
-        && chmod +x /bin/docker* \
-        && pip install docker-compose==${DOCKER_COMPOSE_VERSION} \
-        && curl -fL "https://github.com/jwilder/docker-squash/releases/download/v${DOCKER_SQUASH}/docker-squash-linux-amd64-v${DOCKER_SQUASH}.tar.gz" | tar zx \
-        && mv /docker-squash* /bin/ \
-        && chmod +x /bin/docker-squash* \
-        && rm -rf /var/cache/apk/* \
-        && rm -rf /root/.cache
+  && apt-get -y install bash curl iptables ca-certificates gnupg net-tools iproute2 make \
+  && curl -fL "https://download.docker.com/linux/static/${DOCKER_CHANNEL}/x86_64/docker-${DOCKER_VERSION}.tgz" | tar zx \
+  && mv /docker/* /bin/ \
+  && chmod +x /bin/docker* \
+  && curl -L "https://github.com/docker/compose/releases/download/v${DOCKER_COMPOSE_VERSION}/docker-compose-linux-$(uname -m)" -o /bin/docker-compose \
+  && chmod +x /bin/docker-compose \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /shared
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV DOCKER_CHANNEL=stable \
   DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
-  && apt-get -y install bash curl iptables ca-certificates make pigz \
+  && apt-get -y install bash curl iptables ca-certificates make net-tools iproute2 pigz \
   && curl -fL "https://download.docker.com/linux/static/${DOCKER_CHANNEL}/x86_64/docker-${DOCKER_VERSION}.tgz" | tar zx \
   && mv /docker/* /bin/ \
   && chmod +x /bin/docker* \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -169,3 +169,4 @@ if [[ "$#" != "0" ]]; then
   "$@"
 else
   bash --login
+fi


### PR DESCRIPTION
Hi :wave: 

Thanks for providing the awesome concourse-dind image.

I made a few tweaks on your concourse-dind, namely:

* use `ubuntu:focal` as the base image
* bump the docker & compose version to newer versions
* some bash script fixes

